### PR TITLE
Update foodpoison.statuseffect.patch

### DIFF
--- a/stats/effects/foodpoison/foodpoison.statuseffect.patch
+++ b/stats/effects/foodpoison/foodpoison.statuseffect.patch
@@ -2,6 +2,6 @@
   {
     "op": "replace",
     "path": "/blockingStat",
-    "value": "srm_shoggothracial"
+    "value": "srm_eldritchracial"
   }
 ]

--- a/stats/effects/foodpoison/foodpoison.statuseffect.patch
+++ b/stats/effects/foodpoison/foodpoison.statuseffect.patch
@@ -1,7 +1,7 @@
 [
   {
-    "op": "replace",
-    "path": "/blockingStat",
+    "op": "add",
+    "path": "/blockingStat/-",
     "value": "srm_eldritchracial"
   }
 ]


### PR DESCRIPTION
Points to the correct effect now.
(Change of standard was not universal, at some point, so any "srm_shoggoth" non-unique file should be "srm_eldritch".)